### PR TITLE
Fix typo in Samsung Certificate instructions 

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ This is a **community-driven project** and is **not officially affiliated with o
 
 ## 📝 Additional Note
 
-You need to make a Samsung Certificate (Tools > Certficate Manager) to run any of the packages above. In case you're having any issues, refer to [Connection Guide](https://developer.samsung.com/smarttv/develop/getting-started/using-sdk/tv-device.html).
+You need to make a Samsung Certificate (Tools > Certficate Manager) to run any of the packages listed above. In case you're having any issues, refer to [Connection Guide](https://developer.samsung.com/smarttv/develop/getting-started/using-sdk/tv-device.html).
 
 ---
 


### PR DESCRIPTION
Added a reminder to create a samsung certificate to run the packages.

P.S: I made TVapp. I really appreciate what you're doing. Happy to be part of this!