### PR TITLE
Update self-references after transfer to Apps2Samsung org

### DIFF
--- a/.github/state/last_seen.json
+++ b/.github/state/last_seen.json
@@ -19,5 +19,5 @@
   "direct:KaashDev/TVapp": "etag:\"e5943bc9a636a9d3b4a433a5ec11b98a850873ef222389d67027b81bff703fd3\"|mod:|len:45372",
   "direct:yadPe/PlayerAVPlay": "etag:\"86d18fae091a6bb45afea7897ba07656ac8c1c6123440d25cddd8ca944129b26\"|mod:|len:32385",
   "direct:futo-org/FCastReceiver": "etag:\"ffdc59301ed48f6a265c93ec27b7b263\"|mod:Wed, 08 Oct 2025 17:07:02 GMT|len:6669120",
-  "direct:PatrickSt1991/tizen-community-packages": "etag:\"76c7abc2fc40f84b17ac2acf306749e29bf1461541ceb65d5600f2f5e6555842\"|mod:|len:3130441"
+  "direct:Apps2Samsung/tizen-community-packages": "etag:\"76c7abc2fc40f84b17ac2acf306749e29bf1461541ceb65d5600f2f5e6555842\"|mod:|len:3130441"
 }

--- a/.github/workflows/sync-packages.yml
+++ b/.github/workflows/sync-packages.yml
@@ -169,7 +169,7 @@ jobs:
         run: |
           mkdir -p tizen-studio
           curl -L -o tizen-installer \
-            "https://github.com/PatrickSt1991/tizen-community-packages/releases/download/tizen-deps-5.5/web-cli_Tizen_Studio_4.0_ubuntu-64.bin"
+            "https://github.com/Apps2Samsung/tizen-community-packages/releases/download/tizen-deps-5.5/web-cli_Tizen_Studio_4.0_ubuntu-64.bin"
           chmod +x tizen-installer
           ./tizen-installer --accept-license "$GITHUB_WORKSPACE/tizen-studio"
           rm tizen-installer

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # 🌐 Tizen Community Packages
-[![Sync Tizen Community Packages](https://github.com/PatrickSt1991/tizen-community-packages/actions/workflows/sync-packages.yml/badge.svg)](https://github.com/PatrickSt1991/tizen-community-packages/actions/workflows/sync-packages.yml)
+[![Sync Tizen Community Packages](https://github.com/Apps2Samsung/tizen-community-packages/actions/workflows/sync-packages.yml/badge.svg)](https://github.com/Apps2Samsung/tizen-community-packages/actions/workflows/sync-packages.yml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Contributions Welcome](https://img.shields.io/badge/Contributions-Welcome-green.svg)](../../issues)
 [![Tizen](https://img.shields.io/badge/Platform-Tizen-lightgrey.svg)](https://www.tizen.org/)

--- a/repos-sync.json
+++ b/repos-sync.json
@@ -75,8 +75,8 @@
       "url": "https://dl.fcast.org/tizen/1.0.0/FCastReceiver.wgt",
       "output_name": "FCastReceiver.wgt"
     },
-    "PatrickSt1991/tizen-community-packages": {
-      "url": "https://raw.githubusercontent.com/PatrickSt1991/tizen-community-packages/main/Stremio.wgt",
+    "Apps2Samsung/tizen-community-packages": {
+      "url": "https://raw.githubusercontent.com/Apps2Samsung/tizen-community-packages/main/Stremio.wgt",
       "output_name": "Stremio-Tizen4.wgt"
     }
   }


### PR DESCRIPTION
Follow-up to the org transfer: the sync badge, the Tizen Studio asset URL in the sync workflow, the self-referencing `direct` entry in `repos-sync.json` (key + raw URL), and its `last_seen.json` state key now point at `Apps2Samsung/tizen-community-packages`.

Old URLs kept working via GitHub redirects — this is cleanup so nothing depends on the redirect.

Source-repo entries under `PatrickSt1991/…` (vlc-tizen-tv, Sportlink, chorus2-tizen, flixor-tizen, NuvioWeb) are deliberately untouched — those repos still live under the personal account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)